### PR TITLE
Fix likely typo in TRBM example script

### DIFF
--- a/MAIN_TRBM.m
+++ b/MAIN_TRBM.m
@@ -276,6 +276,6 @@ Z_Nt = 5000; % number of time bins for simuation
 [ logZ ] = TRBM_logZ_Annealed_Importance_Sampling( M, Z_K, Z_Nt, loglikel_Nbin); % log partition function
 
 % Mean response log likelihood
-loglikel_train_m = mean( TRBM_mF_cyclic_given_Nb(M, loglikel_Nbin, resp_like_train, loglikel_Nbin)) - logZ
-loglikel_test_m  = mean( TRBM_mF_cyclic_given_Nb(M, loglikel_Nbin, resp_like_test,  loglikel_Nbin)) - logZ
+loglikel_train_m = mean( TRBM_mF_cyclic_given_Nb(M, loglikel_Nbin, resp_train, loglikel_Nbin)) - logZ
+loglikel_test_m  = mean( TRBM_mF_cyclic_given_Nb(M, loglikel_Nbin, resp_test,  loglikel_Nbin)) - logZ
 


### PR DESCRIPTION
I know there's other things that need being set by hand before one can run the script on their machine (most importantly, one needs data!), but this seems unintentional, as `resp_like_train` and `resp_like_test` are not defined anywhere.